### PR TITLE
chore(tox.ini): Add usedevelop = True

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands = pytest
 deps =
 	-r{toxinidir}/requirements/lck/main.txt
 	-r{toxinidir}/requirements/lck/test.txt
+usedevelop = True
 
 [testenv:ci]
 commands = codecov


### PR DESCRIPTION
Just before the coverage would print out, there was a warning about no
coverage data being collected:

```
test/test_minecraft.py::TestMinecraft::test__really_old_protocol_empty_motds_are_supported PASSED [ 96%]
test/test_minecraft.py::TestMinecraft::test__removes_ansi_escapes_from_motd PASSED [100%]Coverage.py warning: No data was collected. (no-data-collected)

----------- coverage: platform linux, python 3.6.4-final-0 -----------
```

As per, https://github.com/pytest-dev/pytest-cov/issues/98#issuecomment-320282741, adding `usedevelop = True` fixes this.